### PR TITLE
[change] Allow unarchiving Keychain values

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,17 @@ SInfo.setItem('key1', 'value1', {
 
 Note: By default `kSecAccessControl` will get set to `kSecAccessControlUserPresence`.
 
+#### unarchiveValue
+
+Setting the `unarchiveValue` option as `true` will utilize [`NSKeyedUnarchiver`](https://developer.apple.com/documentation/foundation/nskeyedunarchiver) to unarchive the Keychain value. This is useful for when retrieving a value that was archived when originally stored (e.g. created by [`Locksmith`](https://git.io/fhYw0)). This option is only supported by `getItem`.
+
+```javascript
+SInfo.getItem('key1', {
+  keychainService: 'myKeychain',
+  unarchiveValue: true,
+});
+```
+
 # How to use?
 
 Here is a simple example:

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,7 @@ export interface RNSensitiveInfoOptions {
   kSecUseOperationPrompt?: string;
   sharedPreferencesName?: string;
   touchID?: boolean;
+  unarchiveValue: boolean;
 }
 
 export declare function setItem(key: string, value: string, options: RNSensitiveInfoOptions): Promise<null>;

--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -170,7 +170,13 @@ RCT_EXPORT_METHOD(getItem:(NSString *)key options:(NSDictionary *)options resolv
       resolve(nil);
   } else {
       // Found
-      NSString* value = [[NSString alloc] initWithData:[found objectForKey:(__bridge id)(kSecValueData)] encoding:NSUTF8StringEncoding];
+      NSString* value = nil;
+      if ([RCTConvert BOOL:options[@"unarchiveValue"]]) {
+        NSData* data = [[NSData alloc] initWithData:[found objectForKey:(__bridge id)(kSecValueData)]];
+        value = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+      } else {
+        value = [[NSString alloc] initWithData:[found objectForKey:(__bridge id)(kSecValueData)] encoding:NSUTF8StringEncoding];
+      }
       resolve(value);
 
   }


### PR DESCRIPTION
Provide an `unarchiveValue` option for the `getItem` method. This allows
for Keychain values to be unarchived during the retrieval process. This
is required to access preexisting Keychain values created by
[Locksmith](https://git.io/fhYw0).