### PR TITLE
[fix] Missing options argument for archived data

### DIFF
--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -187,15 +187,15 @@ RCT_EXPORT_METHOD(getItem:(NSString *)key options:(NSDictionary *)options resolv
                                   return;
                               }
                               
-                              [self getItemWithQuery:query resolver:resolve rejecter:reject];
+                              [self getItemWithQuery:query resolver:resolve rejecter:reject options:options];
                           }];
         return;
     }
     
-    [self getItemWithQuery:query resolver:resolve rejecter:reject];
+    [self getItemWithQuery:query resolver:resolve rejecter:reject options:options];
 }
 
-- (void)getItemWithQuery:(NSDictionary *)query resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject {
+- (void)getItemWithQuery:(NSDictionary *)query resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject options:(NSDictionary *)options {
     // Look up server in the keychain
     NSDictionary* found = nil;
     CFTypeRef foundTypeRef = NULL;


### PR DESCRIPTION
When we rebased, we neglected to add `options` to the new method we added our changes for access archived data to. This passes the `options` parameter to the new method that was added.

I also accidentally pushed a PR to the [original repo](https://github.com/mCodex/react-native-sensitive-info/pull/151) 😓 